### PR TITLE
Improve Wake-on-LAN management script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # wol-script-pi
 
-This repository contains a small Bash script to wake several servers using Wake-on-LAN. The script checks whether each host is reachable and sends magic packets when needed.
+This repository contains a Bash script that keeps Proxmox nodes awake by sending Wake-on-LAN packets when they become unreachable. The script can run from cron or a systemd timer and logs to the system journal.
 
 ## Usage
 
-1. Edit the `HOSTS` and `MACS` arrays in `power-on-server.sh` so that each MAC corresponds to the matching host.
-2. Ensure the `wakeonlan` and `etherwake` utilities are installed on the system running the script.    
-    The script checks for these commands and aborts if they are missing. Array lengths are also verified.
+1. Create `/etc/power-on-cluster.conf` with one `ip|mac` pair per line. Example:
+
+```
+192.168.10.53|48:21:0b:5a:45:49
+192.168.10.51|88:ae:dd:04:b6:64
+```
+
+2. Ensure the following utilities are installed: `wakeonlan`, `etherwake`, `flock`, and `logger` (usually part of util-linux). The script checks for these commands.
 3. Make the script executable and run it manually:
 
 ```bash
@@ -14,10 +19,10 @@ chmod +x power-on-server.sh
 ./power-on-server.sh
 ```
 
-For unattended operation, schedule the script via cron:
+For unattended operation schedule it via cron or a systemd timer. A simple cron entry:
 
 ```
-@hourly /usr/bin/bash /home/pi/power-on-server.sh >>/home/pi/power-on-server.log 2>&1
+@hourly /usr/bin/bash /path/to/power-on-server.sh
 ```
 
 ## Dependencies
@@ -25,5 +30,6 @@ For unattended operation, schedule the script via cron:
 - bash
 - wakeonlan
 - etherwake
+- util-linux (for `flock` and `logger`)
 
 The script was adapted from content published by technotim.

--- a/power-on-server.sh
+++ b/power-on-server.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# power-on-cluster.sh – keep Proxmox nodes awake from a Pi Zero 2 W
+#   • Runs safely from systemd-timer *or* cron
+#   • Uses flock to prevent concurrent runs
+#   • Reads host ↔︎ MAC mapping from /etc/power-on-cluster.conf to avoid
+#     hard-coding values in the script
+#   • Logs to journald via ‘logger’ for easy filtering
+#   • Reboots the Pi only when *all* targets remain unreachable after N tries
+#   • Shell-checked and set-euxo pipefail for robustness
+
+set -Eeuo pipefail
+shopt -s inherit_errexit         # propagate ‘set -e’ into subshells (bash 5.0+)
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# ────────────────────────────────────────────────────────────────────────────
+# sanity-check utilities we depend on
 require_commands() {
     for cmd in "$@"; do
         if ! command -v "$cmd" >/dev/null; then
@@ -18,24 +30,39 @@ verify_arrays() {
     fi
 }
 
-# Runs hourly via cron: crontab -e
-# @hourly /usr/bin/bash /home/pi/power-on-server.sh >>/home/pi/power-on-server.log 2>&1
+###
+# CONFIG  (one host per line:  ip|mac )
+# Example:
+#   192.168.10.53|48:21:0b:5a:45:49
+#   192.168.10.51|88:ae:dd:04:b6:64
+# Store this in /etc/power-on-cluster.conf (chmod 644)
+###
+CONF_FILE=/etc/power-on-cluster.conf
 
-HOSTS=(192.168.10.53 192.168.10.51 192.168.10.50 192.168.0.76)
-MACS=(48:21:0b:5a:45:49 88:ae:dd:04:b6:64 88:ae:dd:07:f3:15 dc:a6:32:7d:55:29)
-
-require_commands wakeonlan etherwake
+mapfile -t HOSTS < <(awk -F'|' '{print $1}' "$CONF_FILE")
+mapfile -t MACS  < <(awk -F'|' '{print $2}' "$CONF_FILE")
 verify_arrays
-PING='/bin/ping -q -c1 -W1'     # 1-second timeout
+require_commands wakeonlan etherwake flock logger systemctl
+
+LOCK_FD=200
+exec {LOCK_FD}>/run/power-on-cluster.lock
+flock -n "$LOCK_FD" || {
+    logger -t power-on-cluster "Previous run still active – aborting"
+    exit 0
+}
+
+PING='/bin/ping -q -c1 -W1'     # 1 s timeout
+MAX_TRIES=5
+SLEEP_BETWEEN=10                # seconds between WoL bursts
 
 is_up() { $PING "$1" &>/dev/null; }
 
 wake_up() {
     local mac=$1 host=$2
-    for _ in {1..5}; do
-        wakeonlan "$mac"
-        etherwake "$mac"
-        sleep 10
+    for ((i=1; i<=MAX_TRIES; i++)); do
+        wakeonlan "$mac" || true   # ignore exit codes – some NICs answer only to one tool
+        etherwake "$mac"   || true
+        sleep "$SLEEP_BETWEEN"
         is_up "$host" && return 0
     done
     return 1
@@ -43,8 +70,8 @@ wake_up() {
 
 check_network() {
     if ! is_up 1.1.1.1 && ! is_up 8.8.8.8; then
-        echo "$(date)  Internet unreachable – restarting network"
-        systemctl restart systemd-networkd   # adjust for your setup
+        logger -t power-on-cluster "Internet unreachable – restarting network stack"
+        systemctl restart systemd-networkd || logger -t power-on-cluster "network restart failed"
         sleep 10
     fi
 }
@@ -53,17 +80,17 @@ down=0
 for i in "${!HOSTS[@]}"; do
     host=${HOSTS[$i]}
     if ! is_up "$host"; then
-        echo "$(date)  $host is down"
+        logger -t power-on-cluster "$host is down – attempting WoL"
         check_network
         wake_up "${MACS[$i]}" "$host" || ((down++))
     else
-        echo "$(date)  $host is up"
+        logger -t power-on-cluster "$host is up"
     fi
 done
 
-if (( down == ${#HOSTS[@]} )); then        # reboot only if *all* are still down
-    echo "$(date)  All hosts down – rebooting Pi"
-    /sbin/shutdown -r now
+if (( down == ${#HOSTS[@]} )); then
+    logger -t power-on-cluster "All hosts remain unreachable – rebooting Pi"
+    systemctl reboot
 else
-    echo "$(date)  Reboot skipped – at least one host is up"
+    logger -t power-on-cluster "At least one host reachable – no reboot needed"
 fi


### PR DESCRIPTION
## Summary
- enhance `power-on-server.sh` to use config files and systemd friendly logging
- prevent overlapping runs with `flock`
- add instructions for configuration and dependencies in README

## Testing
- `shellcheck power-on-server.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858f281f9888324801350a3bce79985