### PR TITLE
Embed host mappings in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ This repository contains a Bash script that keeps Proxmox nodes awake by sending
 
 ## Usage
 
-1. Create `/etc/power-on-cluster.conf` with one `ip|mac` pair per line. Example:
-
-```
-192.168.10.53|48:21:0b:5a:45:49
-192.168.10.51|88:ae:dd:04:b6:64
-```
+1. Edit the `HOSTS` and `MACS` arrays at the top of `power-on-server.sh` with
+   the IP and MAC address pairs for your nodes.
 
 2. Ensure the following utilities are installed: `wakeonlan`, `etherwake`, `flock`, and `logger` (usually part of util-linux). The script checks for these commands.
 3. Make the script executable and run it manually:

--- a/power-on-server.sh
+++ b/power-on-server.sh
@@ -2,8 +2,7 @@
 # power-on-cluster.sh – keep Proxmox nodes awake from a Pi Zero 2 W
 #   • Runs safely from systemd-timer *or* cron
 #   • Uses flock to prevent concurrent runs
-#   • Reads host ↔︎ MAC mapping from /etc/power-on-cluster.conf to avoid
-#     hard-coding values in the script
+#   • Uses built-in host ↔︎ MAC mappings
 #   • Logs to journald via ‘logger’ for easy filtering
 #   • Reboots the Pi only when *all* targets remain unreachable after N tries
 #   • Shell-checked and set-euxo pipefail for robustness
@@ -31,16 +30,18 @@ verify_arrays() {
 }
 
 ###
-# CONFIG  (one host per line:  ip|mac )
-# Example:
-#   192.168.10.53|48:21:0b:5a:45:49
-#   192.168.10.51|88:ae:dd:04:b6:64
-# Store this in /etc/power-on-cluster.conf (chmod 644)
+# HOST ↔ MAC mappings
+# Define the IP and MAC pairs directly in the script.
+# Example values are shown below – adjust for your environment.
 ###
-CONF_FILE=/etc/power-on-cluster.conf
-
-mapfile -t HOSTS < <(awk -F'|' '{print $1}' "$CONF_FILE")
-mapfile -t MACS  < <(awk -F'|' '{print $2}' "$CONF_FILE")
+HOSTS=(
+    192.168.10.53
+    192.168.10.51
+)
+MACS=(
+    48:21:0b:5a:45:49
+    88:ae:dd:04:b6:64
+)
 verify_arrays
 require_commands wakeonlan etherwake flock logger systemctl
 


### PR DESCRIPTION
## Summary
- move host MAC mappings inside `power-on-server.sh`
- update README instructions for editing arrays

## Testing
- `shellcheck power-on-server.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858f3ec32a88324bef64f8225b559eb